### PR TITLE
Save scale + add end crystals

### DIFF
--- a/src/slapper/Main.php
+++ b/src/slapper/Main.php
@@ -29,6 +29,7 @@ use pocketmine\utils\Utils;
 use pocketmine\world\Location;
 use pocketmine\world\World;
 use slapper\entities\other\SlapperBoat;
+use slapper\entities\SlapperEndCrystal;
 use slapper\entities\other\SlapperFallingSand;
 use slapper\entities\other\SlapperMinecart;
 use slapper\entities\other\SlapperPrimedTNT;
@@ -99,7 +100,7 @@ class Main extends PluginBase implements Listener {
         "Husk", "WitherSkeleton", "IronGolem", "Snowman",
         "LavaSlime", "Squid", "ElderGuardian", "Endermite",
         "Evoker", "Guardian", "PolarBear", "Shulker",
-        "Vex", "Vindicator", "Wither", "Llama"
+        "Vex", "Vindicator", "Wither", "Llama", "EndCrystal"
     ];
 
     const ENTITY_ALIASES = [
@@ -188,7 +189,7 @@ class Main extends PluginBase implements Listener {
              SlapperFallingSand::class, SlapperElderGuardian::class, SlapperEndermite::class,
              SlapperEvoker::class, SlapperGuardian::class, SlapperLlama::class,
              SlapperPolarBear::class, SlapperShulker::class, SlapperVex::class,
-             SlapperVindicator::class, SlapperWither::class
+             SlapperVindicator::class, SlapperWither::class, SlapperEndCrystal::class
         ] as $className){
             $stringPos = strpos($className, 'Slapper');
             if($stringPos === false){

--- a/src/slapper/entities/SlapperEndCrystal.php
+++ b/src/slapper/entities/SlapperEndCrystal.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace slapper\entities;
+
+use pocketmine\data\bedrock\EntityLegacyIds;
+use slapper\entities\SlapperEntity;
+
+class SlapperEndCrystal extends SlapperEntity {
+
+	const TYPE_ID = EntityLegacyIds::ENDER_CRYSTAL;
+	const HEIGHT = 1.8;
+
+}

--- a/src/slapper/entities/SlapperEntity.php
+++ b/src/slapper/entities/SlapperEntity.php
@@ -60,7 +60,7 @@ class SlapperEntity extends Entity implements SlapperInterface{
         $this->setImmobile(true);
         $this->setNameTagVisible(false);
 
-		if($nbt->getFloat("Scale", -1) !== -1){
+		if($nbt->getTag("Scale") !== null){
 			$this->setScale($nbt->getFloat("Scale"));
 		}
     }

--- a/src/slapper/entities/SlapperEntity.php
+++ b/src/slapper/entities/SlapperEntity.php
@@ -59,6 +59,10 @@ class SlapperEntity extends Entity implements SlapperInterface{
         $this->version = $nbt->getString('SlapperVersion', '');
         $this->setImmobile(true);
         $this->setNameTagVisible(false);
+
+		if($nbt->getFloat("Scale", -1) !== -1){
+			$this->setScale($nbt->getFloat("Scale"));
+		}
     }
 
     //For backwards-compatibility
@@ -71,6 +75,7 @@ class SlapperEntity extends Entity implements SlapperInterface{
             $commandsTag->push(new StringTag($command));
         }
         $nbt->setString('SlapperVersion', $this->version);
+		$nbt->setFloat("Scale", $this->scale);
         return $nbt;
     }
 


### PR DESCRIPTION
Unlike the original slapper plugin the scale of the entity isn't saved thus after a reboot the scale of the entity changes back to default. That issue has been fixed.

End crystals have been added.