### PR TITLE
[-] `mcpe-protocol`

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: Slapper
 author: [Vecnavium, jojoe77777]
-version: 2.0.6
+version: 2.0.7
 description: Slapper, the NPC plugin for PocketMine-MP
 main: slapper\Main
 api: 4.0.0

--- a/plugin.yml
+++ b/plugin.yml
@@ -4,7 +4,6 @@ version: 2.0.6
 description: Slapper, the NPC plugin for PocketMine-MP
 main: slapper\Main
 api: 4.0.0
-mcpe-protocol: 486
 
 commands:
   slapper:


### PR DESCRIPTION
This PR removes mcpe-protocol from slapper.

https://poggit.pmmp.io/rules.edit
Rule B7 is removed therefore `mcpe-protocol` is no longer required.