### PR TITLE
Fixed issue of: Living::getDisplayName()

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,10 +1,10 @@
 name: Slapper
 author: [Vecnavium, jojoe77777]
-version: 2.1.3
+version: 2.1.4
 description: Slapper, the NPC plugin for PocketMine-MP
 main: slapper\Main
 api: 4.0.0
-mcpe-protocol: 557
+mcpe-protocol: 560
 
 commands:
   slapper:

--- a/src/slapper/SlapperTrait.php
+++ b/src/slapper/SlapperTrait.php
@@ -38,7 +38,7 @@ trait SlapperTrait {
         //NOOP
     }
 
-    public function getDisplayName(Player $player): string {
+    public function getSlapperDisplayName(Player $player): string {
         $vars = [
             "{name}" => $player->getName(),
             "{display_name}" => $player->getDisplayName(),

--- a/src/slapper/entities/SlapperEntity.php
+++ b/src/slapper/entities/SlapperEntity.php
@@ -83,7 +83,7 @@ class SlapperEntity extends Entity implements SlapperInterface{
     protected function sendSpawnPacket(Player $player): void {
         parent::sendSpawnPacket($player);
 
-        $this->particle->setTitle($this->getDisplayName($player));
+        $this->particle->setTitle($this->getSlapperDisplayName($player));
         $this->getWorld()->addParticle($this->location->asVector3()->add(0, static::HEIGHT, 0), $this->particle, [$player]);
     }
 
@@ -120,7 +120,7 @@ class SlapperEntity extends Entity implements SlapperInterface{
         $world = $this->getWorld();
         $particlePos = $this->location->asVector3()->add(0, static::HEIGHT, 0);
         foreach($players as $player){
-            $this->particle->setTitle($this->getDisplayName($player));
+            $this->particle->setTitle($this->getSlapperDisplayName($player));
             $world->addParticle($particlePos, $this->particle, [$player]);
         }
     }

--- a/src/slapper/entities/SlapperHuman.php
+++ b/src/slapper/entities/SlapperHuman.php
@@ -78,7 +78,7 @@ class SlapperHuman extends Human implements SlapperInterface{
             return;
         }
         foreach($targets as $p){
-            $data[EntityMetadataProperties::NAMETAG] = new StringMetadataProperty($this->getDisplayName($p));
+            $data[EntityMetadataProperties::NAMETAG] = new StringMetadataProperty($this->getSlapperDisplayName($p));
             $p->getNetworkSession()->syncActorData($this, $data);
         }
     }


### PR DESCRIPTION
* Renamed function "[getDisplayName()](https://github.com/vecnavium-pm-pl/Slapper/blob/547a78ba7781d13a6de96a7a4e25743a10ff3575/src/slapper/SlapperTrait.php#L41)" to "[getSlapperDisplayName()](https://github.com/ACM-PocketMine-MP/Slapper/blob/a25360b9e5a7e81119805cbcbe94dbe4e71c5f53/src/slapper/SlapperTrait.php#L41)"

* New version & protocol change to the current one: 560