### PR TITLE
Support for PM 4.13+

### DIFF
--- a/src/slapper/SlapperTrait.php
+++ b/src/slapper/SlapperTrait.php
@@ -38,7 +38,7 @@ trait SlapperTrait {
         //NOOP
     }
 
-    public function getDisplayName(Player $player): string {
+    public function getDisplayNameTag(Player $player): string {
         $vars = [
             "{name}" => $player->getName(),
             "{display_name}" => $player->getDisplayName(),

--- a/src/slapper/entities/SlapperEntity.php
+++ b/src/slapper/entities/SlapperEntity.php
@@ -83,7 +83,7 @@ class SlapperEntity extends Entity implements SlapperInterface{
     protected function sendSpawnPacket(Player $player): void {
         parent::sendSpawnPacket($player);
 
-        $this->particle->setTitle($this->getDisplayName($player));
+        $this->particle->setTitle($this->getDisplayNameTag($player));
         $this->getWorld()->addParticle($this->location->asVector3()->add(0, static::HEIGHT, 0), $this->particle, [$player]);
     }
 
@@ -120,7 +120,7 @@ class SlapperEntity extends Entity implements SlapperInterface{
         $world = $this->getWorld();
         $particlePos = $this->location->asVector3()->add(0, static::HEIGHT, 0);
         foreach($players as $player){
-            $this->particle->setTitle($this->getDisplayName($player));
+            $this->particle->setTitle($this->getDisplayNameTag($player));
             $world->addParticle($particlePos, $this->particle, [$player]);
         }
     }

--- a/src/slapper/entities/SlapperHuman.php
+++ b/src/slapper/entities/SlapperHuman.php
@@ -78,7 +78,7 @@ class SlapperHuman extends Human implements SlapperInterface{
             return;
         }
         foreach($targets as $p){
-            $data[EntityMetadataProperties::NAMETAG] = new StringMetadataProperty($this->getDisplayName($p));
+            $data[EntityMetadataProperties::NAMETAG] = new StringMetadataProperty($this->getDisplayNameTag($p));
             $p->getNetworkSession()->syncActorData($this, $data);
         }
     }


### PR DESCRIPTION
PM added `Living::getDisplayName()` in 4.13
```
The following new API methods have been added:
    public Living->getDisplayName() : string - the name of the entity to be shown in death messages, commands etc.
```
https://github.com/pmmp/PocketMine-MP/commit/d476a4c1aa1dd2714535f82a63b6aa1876d78601

Which causes incompatibility with the `SlapperTrait::getDisplayName()` method, the solution of this PR is to rename the method to a more appropriate name

